### PR TITLE
Explicitly specifying the encoding to "utf-8".

### DIFF
--- a/pypredef_gen.py
+++ b/pypredef_gen.py
@@ -999,7 +999,7 @@ def bpy2predef(BASEPATH, title):
     structs, funcs, ops, props = rna_info.BuildRNAInfo()
     #open the file:
     filepath = os.path.join(BASEPATH, "bpy.py")
-    file = open(filepath, "w")
+    file = open(filepath, "w", encoding="utf-8")
     fw = file.write
     #Start the file:
     definition = doc2definition(title,"") #skip the leading spaces at the first line...


### PR DESCRIPTION
This fixes a crash of the script. Without explicitly stating the encoding, it raises a UnicodeEncodeError:

```
(...)
class FaceMaps:

class FieldSettings:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "D:\Projects\Blender Addons\predef\pypredef_gen.py", line 1177, in <module>
    main() #just run it! Unconditional call makes it easier to debug Blender script in Eclipse,
  File "D:\Projects\Blender Addons\predef\pypredef_gen.py", line 1144, in main
    rna2predef(path_in_tmp)
  File "D:\Projects\Blender Addons\predef\pypredef_gen.py", line 1053, in rna2predef
    bpy2predef(BASEPATH,"Blender API main module")
  File "D:\Projects\Blender Addons\predef\pypredef_gen.py", line 1036, in bpy2predef
    rna_struct2predef(_IDENT, fw, cls)
  File "D:\Projects\Blender Addons\predef\pypredef_gen.py", line 917, in rna_struct2predef
    rna_property2predef(ident,fw,prop)
  File "D:\Projects\Blender Addons\predef\pypredef_gen.py", line 876, in rna_property2predef
    write_indented_lines(ident, fw, definition["docstring"], False)
  File "D:\Projects\Blender Addons\predef\pypredef_gen.py", line 172, in write_indented_lines
    fn(ident + l + "\n")
  File "D:\Programs\Blender 2.81\2.81\python\lib\encodings\cp1250.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode character '\xb2' in position 37: character maps to <undefined>

Blender quit
```